### PR TITLE
무한스크롤로 바위 목록 조회 시 정렬 기능 구현

### DIFF
--- a/src/main/java/com/line7studio/boulderside/application/boulder/BoulderUseCase.java
+++ b/src/main/java/com/line7studio/boulderside/application/boulder/BoulderUseCase.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,8 +40,8 @@ public class BoulderUseCase {
 	private final BoulderQueryService boulderQueryService;
 	private final UserBoulderLikeService userBoulderLikeService;
 
-	public BoulderPageResponse getBoulderPage(Long cursor, int size) {
-		List<BoulderWithRegion> boulderWithRegionList = boulderQueryService.getBoulderWithRegionList(cursor, size);
+	public BoulderPageResponse getBoulderPage(BoulderSortType sortType, Long cursor, int size) {
+		List<BoulderWithRegion> boulderWithRegionList = boulderQueryService.getBoulderWithRegionList(sortType, cursor, size);
 		List<Long> boulderIdList = boulderWithRegionList.stream().map(BoulderWithRegion::getId).toList();
 		List<Image> imageList = imageService.getImageListByTargetTypeAndTargetIdList(TargetType.BOULDER, boulderIdList);
 

--- a/src/main/java/com/line7studio/boulderside/application/boulder/BoulderUseCase.java
+++ b/src/main/java/com/line7studio/boulderside/application/boulder/BoulderUseCase.java
@@ -40,8 +40,8 @@ public class BoulderUseCase {
 	private final BoulderQueryService boulderQueryService;
 	private final UserBoulderLikeService userBoulderLikeService;
 
-	public BoulderPageResponse getBoulderPage(BoulderSortType sortType, Long cursor, int size) {
-		List<BoulderWithRegion> boulderWithRegionList = boulderQueryService.getBoulderWithRegionList(sortType, cursor, size);
+	public BoulderPageResponse getBoulderPage(BoulderSortType sortType, Long cursor, Long cursorLikeCount, int size) {
+		List<BoulderWithRegion> boulderWithRegionList = boulderQueryService.getBoulderWithRegionList(sortType, cursor, cursorLikeCount, size);
 		List<Long> boulderIdList = boulderWithRegionList.stream().map(BoulderWithRegion::getId).toList();
 		List<Image> imageList = imageService.getImageListByTargetTypeAndTargetIdList(TargetType.BOULDER, boulderIdList);
 
@@ -69,11 +69,14 @@ public class BoulderUseCase {
 			})
 			.toList();
 
-		Long nextCursor = hasNext
-			? boulderResponseList.getLast().getId()
-			: null;
+		Long nextCursor = null;
+		Long nextCursorLikeCount = null;
+		if(hasNext){
+			nextCursor = boulderResponseList.getLast().getId();
+			nextCursorLikeCount = boulderResponseList.getLast().getLikeCount();
+		}
 
-		return BoulderPageResponse.of(boulderResponseList, nextCursor, hasNext,
+		return BoulderPageResponse.of(boulderResponseList, nextCursor, nextCursorLikeCount, hasNext,
 			Math.min(size, boulderWithRegionListSize));
 	}
 

--- a/src/main/java/com/line7studio/boulderside/controller/boulder/BoulderController.java
+++ b/src/main/java/com/line7studio/boulderside/controller/boulder/BoulderController.java
@@ -33,8 +33,9 @@ public class BoulderController {
 	public ResponseEntity<ApiResponse<BoulderPageResponse>> getBoulderPage(
 		@RequestParam(defaultValue = "LATEST") BoulderSortType sortType,
 		@RequestParam(required = false) Long cursor,
+		@RequestParam(required = false) Long cursorLikeCount,
 		@RequestParam(defaultValue = "10") int size) {
-		BoulderPageResponse boulderPageResponse = boulderUseCase.getBoulderPage(sortType, cursor, size);
+		BoulderPageResponse boulderPageResponse = boulderUseCase.getBoulderPage(sortType, cursor, cursorLikeCount, size);
 		return ResponseEntity.ok(ApiResponse.of(boulderPageResponse));
 	}
 

--- a/src/main/java/com/line7studio/boulderside/controller/boulder/BoulderController.java
+++ b/src/main/java/com/line7studio/boulderside/controller/boulder/BoulderController.java
@@ -1,5 +1,6 @@
 package com.line7studio.boulderside.controller.boulder;
 
+import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -30,9 +31,10 @@ public class BoulderController {
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<BoulderPageResponse>> getBoulderPage(
+		@RequestParam(defaultValue = "LATEST") BoulderSortType sortType,
 		@RequestParam(required = false) Long cursor,
-		@RequestParam(defaultValue = "5") int size) {
-		BoulderPageResponse boulderPageResponse = boulderUseCase.getBoulderPage(cursor, size);
+		@RequestParam(defaultValue = "10") int size) {
+		BoulderPageResponse boulderPageResponse = boulderUseCase.getBoulderPage(sortType, cursor, size);
 		return ResponseEntity.ok(ApiResponse.of(boulderPageResponse));
 	}
 

--- a/src/main/java/com/line7studio/boulderside/controller/boulder/response/BoulderPageResponse.java
+++ b/src/main/java/com/line7studio/boulderside/controller/boulder/response/BoulderPageResponse.java
@@ -14,13 +14,15 @@ import lombok.NoArgsConstructor;
 public class BoulderPageResponse {
 	private List<BoulderResponse> content;
 	private Long nextCursor;
+	private Long nextLikeCount;
 	private boolean hasNext;
 	private int size;
 
-	public static BoulderPageResponse of(List<BoulderResponse> content, Long nextCursor, boolean hasNext, int size) {
+	public static BoulderPageResponse of(List<BoulderResponse> content, Long nextCursor, Long nextCursorLikeCount, boolean hasNext, int size) {
 		return BoulderPageResponse.builder()
 			.content(content)
 			.nextCursor(nextCursor)
+			.nextLikeCount(nextCursorLikeCount)
 			.hasNext(hasNext)
 			.size(size)
 			.build();

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/enums/BoulderSortType.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/enums/BoulderSortType.java
@@ -1,0 +1,6 @@
+package com.line7studio.boulderside.domain.aggregate.boulder.enums;
+
+public enum BoulderSortType {
+    LATEST, // 최신순
+    POPULAR; // 좋아요순
+}

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/repository/BoulderQueryRepository.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/repository/BoulderQueryRepository.java
@@ -3,9 +3,10 @@ package com.line7studio.boulderside.domain.aggregate.boulder.repository;
 import java.util.List;
 
 import com.line7studio.boulderside.application.boulder.dto.BoulderWithRegion;
+import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 
 public interface BoulderQueryRepository {
-	List<BoulderWithRegion> findBouldersWithRegionAndCursor(Long cursor, int size);
+	List<BoulderWithRegion> findBouldersWithRegionAndCursor(BoulderSortType sortType, Long cursor, int size);
 
 	BoulderWithRegion findBouldersWithRegionByBoulderId(Long boulderId);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/repository/BoulderQueryRepository.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/repository/BoulderQueryRepository.java
@@ -6,7 +6,7 @@ import com.line7studio.boulderside.application.boulder.dto.BoulderWithRegion;
 import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 
 public interface BoulderQueryRepository {
-	List<BoulderWithRegion> findBouldersWithRegionAndCursor(BoulderSortType sortType, Long cursor, int size);
+	List<BoulderWithRegion> findBouldersWithRegionAndCursor(BoulderSortType sortType, Long cursor, Long cursorLikeCount, int size);
 
 	BoulderWithRegion findBouldersWithRegionByBoulderId(Long boulderId);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/repository/BoulderQueryRepositoryImpl.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/repository/BoulderQueryRepositoryImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 import com.line7studio.boulderside.domain.association.like.entity.QUserBoulderLike;
+import com.querydsl.jpa.JPQLQuery;
 import org.springframework.stereotype.Repository;
 
 import com.line7studio.boulderside.application.boulder.dto.BoulderWithRegion;
@@ -23,14 +24,8 @@ public class BoulderQueryRepositoryImpl implements BoulderQueryRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<BoulderWithRegion> findBouldersWithRegionAndCursor(BoulderSortType sortType, Long cursor, int size) {
-		BooleanExpression predicate = null;
-
-		if (cursor != null && sortType == BoulderSortType.LATEST) {
-			predicate = boulder.id.lt(cursor);
-		}
-
-		return jpaQueryFactory
+	public List<BoulderWithRegion> findBouldersWithRegionAndCursor(BoulderSortType sortType, Long cursor, Long cursorLikeCount, int size) {
+		JPQLQuery<BoulderWithRegion> query =  jpaQueryFactory
 				.select(Projections.constructor(
 						BoulderWithRegion.class,
 						// Boulder
@@ -51,21 +46,36 @@ public class BoulderQueryRepositoryImpl implements BoulderQueryRepository {
 				.from(boulder)
 				.join(region).on(boulder.regionId.eq(region.id))
 				.leftJoin(userBoulderLike).on(userBoulderLike.boulderId.eq(boulder.id))
-				.where(predicate)
 				.groupBy(
 						boulder.id, boulder.name, boulder.description,
 						boulder.latitude, boulder.longitude,
 						boulder.createdAt, boulder.updatedAt,
 						region.id, region.province, region.city,
 						region.regionCode, region.officialDistrictCode
-				)
-				.orderBy(
-						sortType == BoulderSortType.POPULAR
-								? userBoulderLike.count().desc()
-								: boulder.id.desc()
-				)
-				.limit(size + 1)
+				);
+
+		// 정렬 및 커서 조건 처리
+		if (sortType == BoulderSortType.POPULAR) {
+			query.orderBy(userBoulderLike.count().desc(), boulder.id.desc());
+
+			if (cursorLikeCount != null && cursor != null) {
+				query.having(
+						userBoulderLike.count().lt(cursorLikeCount)
+								.or(userBoulderLike.count().eq(cursorLikeCount).and(boulder.id.lt(cursor)))
+				);
+			}
+		} else if (sortType == BoulderSortType.LATEST) {
+			query.orderBy(boulder.id.desc());
+
+			if (cursor != null) {
+				query.where(boulder.id.lt(cursor));
+			}
+		}
+
+		return query
+				.limit(size + 1) // 다음 페이지 유무 확인용
 				.fetch();
+
 	}
 
 	@Override

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/repository/BoulderQueryRepositoryImpl.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/repository/BoulderQueryRepositoryImpl.java
@@ -2,9 +2,12 @@ package com.line7studio.boulderside.domain.aggregate.boulder.repository;
 
 import static com.line7studio.boulderside.domain.aggregate.boulder.entity.QBoulder.*;
 import static com.line7studio.boulderside.domain.aggregate.region.entity.QRegion.*;
+import static com.line7studio.boulderside.domain.association.like.entity.QUserBoulderLike.*;
 
 import java.util.List;
 
+import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
+import com.line7studio.boulderside.domain.association.like.entity.QUserBoulderLike;
 import org.springframework.stereotype.Repository;
 
 import com.line7studio.boulderside.application.boulder.dto.BoulderWithRegion;
@@ -20,35 +23,49 @@ public class BoulderQueryRepositoryImpl implements BoulderQueryRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<BoulderWithRegion> findBouldersWithRegionAndCursor(Long cursor, int size) {
-		BooleanExpression predicate = (cursor != null)
-			? boulder.id.gt(cursor)
-			: null;
+	public List<BoulderWithRegion> findBouldersWithRegionAndCursor(BoulderSortType sortType, Long cursor, int size) {
+		BooleanExpression predicate = null;
+
+		if (cursor != null && sortType == BoulderSortType.LATEST) {
+			predicate = boulder.id.lt(cursor);
+		}
 
 		return jpaQueryFactory
-			.select(Projections.constructor(
-				BoulderWithRegion.class,
-				// Boulder
-				boulder.id,
-				boulder.name,
-				boulder.description,
-				boulder.latitude,
-				boulder.longitude,
-				boulder.createdAt,
-				boulder.updatedAt,
-				// Region
-				region.id,
-				region.province,
-				region.city,
-				region.regionCode,
-				region.officialDistrictCode
-			))
-			.from(boulder)
-			.join(region).on(boulder.regionId.eq(region.id))
-			.where(predicate)
-			.orderBy(boulder.id.asc())
-			.limit(size + 1)
-			.fetch();
+				.select(Projections.constructor(
+						BoulderWithRegion.class,
+						// Boulder
+						boulder.id,
+						boulder.name,
+						boulder.description,
+						boulder.latitude,
+						boulder.longitude,
+						boulder.createdAt,
+						boulder.updatedAt,
+						// Region
+						region.id,
+						region.province,
+						region.city,
+						region.regionCode,
+						region.officialDistrictCode
+				))
+				.from(boulder)
+				.join(region).on(boulder.regionId.eq(region.id))
+				.leftJoin(userBoulderLike).on(userBoulderLike.boulderId.eq(boulder.id))
+				.where(predicate)
+				.groupBy(
+						boulder.id, boulder.name, boulder.description,
+						boulder.latitude, boulder.longitude,
+						boulder.createdAt, boulder.updatedAt,
+						region.id, region.province, region.city,
+						region.regionCode, region.officialDistrictCode
+				)
+				.orderBy(
+						sortType == BoulderSortType.POPULAR
+								? userBoulderLike.count().desc()
+								: boulder.id.desc()
+				)
+				.limit(size + 1)
+				.fetch();
 	}
 
 	@Override

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/service/BoulderQueryService.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/service/BoulderQueryService.java
@@ -3,9 +3,10 @@ package com.line7studio.boulderside.domain.aggregate.boulder.service;
 import java.util.List;
 
 import com.line7studio.boulderside.application.boulder.dto.BoulderWithRegion;
+import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 
 public interface BoulderQueryService {
-	List<BoulderWithRegion> getBoulderWithRegionList(Long cursor, int size);
+	List<BoulderWithRegion> getBoulderWithRegionList(BoulderSortType sortType, Long cursor, int size);
 
 	BoulderWithRegion getBoulderWithRegion(Long boulderId);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/service/BoulderQueryService.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/service/BoulderQueryService.java
@@ -6,7 +6,7 @@ import com.line7studio.boulderside.application.boulder.dto.BoulderWithRegion;
 import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 
 public interface BoulderQueryService {
-	List<BoulderWithRegion> getBoulderWithRegionList(BoulderSortType sortType, Long cursor, int size);
+	List<BoulderWithRegion> getBoulderWithRegionList(BoulderSortType sortType, Long cursor, Long cursorLikeCount, int size);
 
 	BoulderWithRegion getBoulderWithRegion(Long boulderId);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/service/BoulderQueryServiceImpl.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/service/BoulderQueryServiceImpl.java
@@ -16,8 +16,8 @@ public class BoulderQueryServiceImpl implements BoulderQueryService {
 	private final BoulderQueryRepository boulderQueryRepository;
 
 	@Override
-	public List<BoulderWithRegion> getBoulderWithRegionList(BoulderSortType sortType, Long cursor, int size) {
-		return boulderQueryRepository.findBouldersWithRegionAndCursor(sortType, cursor, size);
+	public List<BoulderWithRegion> getBoulderWithRegionList(BoulderSortType sortType, Long cursor, Long cursorLikeCount, int size) {
+		return boulderQueryRepository.findBouldersWithRegionAndCursor(sortType, cursor, cursorLikeCount, size);
 	}
 
 	@Override

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/service/BoulderQueryServiceImpl.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/boulder/service/BoulderQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.line7studio.boulderside.domain.aggregate.boulder.service;
 
 import java.util.List;
 
+import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 import org.springframework.stereotype.Service;
 
 import com.line7studio.boulderside.application.boulder.dto.BoulderWithRegion;
@@ -15,8 +16,8 @@ public class BoulderQueryServiceImpl implements BoulderQueryService {
 	private final BoulderQueryRepository boulderQueryRepository;
 
 	@Override
-	public List<BoulderWithRegion> getBoulderWithRegionList(Long cursor, int size) {
-		return boulderQueryRepository.findBouldersWithRegionAndCursor(cursor, size);
+	public List<BoulderWithRegion> getBoulderWithRegionList(BoulderSortType sortType, Long cursor, int size) {
+		return boulderQueryRepository.findBouldersWithRegionAndCursor(sortType, cursor, size);
 	}
 
 	@Override


### PR DESCRIPTION
## 📌 중점사항

- 기존의 무한스크롤 바위 목록 조회 기능에서 최신순/좋아요순 정렬 기능을 추가하였습니다.
- 기본 정렬 기준은 최신순으로 설정하였습니다.
- 기존의 바위 목록 조회 사이즈를 5에서 10으로 변경하였습니다.

## ℹ️ 참고사항

- ...

## 🏷️ 이슈

- close #32 