### PR TITLE
바위 리스트 조회 시 현재 사용자의 좋아요 여부도 조회하도록 수정

### DIFF
--- a/src/main/java/com/line7studio/boulderside/application/boulder/BoulderUseCase.java
+++ b/src/main/java/com/line7studio/boulderside/application/boulder/BoulderUseCase.java
@@ -40,7 +40,7 @@ public class BoulderUseCase {
 	private final BoulderQueryService boulderQueryService;
 	private final UserBoulderLikeService userBoulderLikeService;
 
-	public BoulderPageResponse getBoulderPage(BoulderSortType sortType, Long cursor, Long cursorLikeCount, int size) {
+	public BoulderPageResponse getBoulderPage(Long userId, BoulderSortType sortType, Long cursor, Long cursorLikeCount, int size) {
 		List<BoulderWithRegion> boulderWithRegionList = boulderQueryService.getBoulderWithRegionList(sortType, cursor, cursorLikeCount, size);
 		List<Long> boulderIdList = boulderWithRegionList.stream().map(BoulderWithRegion::getId).toList();
 		List<Image> imageList = imageService.getImageListByTargetTypeAndTargetIdList(TargetType.BOULDER, boulderIdList);
@@ -65,7 +65,8 @@ public class BoulderUseCase {
 			.map(b -> {
 				List<ImageInfo> imgs = boulderImageInfoMap.getOrDefault(b.getId(), Collections.emptyList());
 				long likeCount = userBoulderLikeService.getCountByBoulderId(b.getId());
-				return BoulderResponse.of(b, imgs, likeCount);
+				boolean liked = userBoulderLikeService.getIsLikedByUserId(b.getId(), userId);
+				return BoulderResponse.of(b, imgs, likeCount, liked);
 			})
 			.toList();
 
@@ -80,7 +81,7 @@ public class BoulderUseCase {
 			Math.min(size, boulderWithRegionListSize));
 	}
 
-	public BoulderResponse getBoulderById(Long boulderId) {
+	public BoulderResponse getBoulderById(Long userId, Long boulderId) {
 		BoulderWithRegion boulderWithRegion = boulderQueryService.getBoulderWithRegion(boulderId);
 		List<Image> imageList = imageService.getImageListByTargetTypeAndTargetId(TargetType.BOULDER, boulderId);
 		List<ImageInfo> imageInfoList = imageList.stream()
@@ -89,8 +90,9 @@ public class BoulderUseCase {
 			.toList();
 
 		long likeCount = userBoulderLikeService.getCountByBoulderId(boulderId);
+		boolean liked = userBoulderLikeService.getIsLikedByUserId(boulderId, userId);
 
-		return BoulderResponse.of(boulderWithRegion, imageInfoList, likeCount);
+		return BoulderResponse.of(boulderWithRegion, imageInfoList, likeCount, liked);
 	}
 
 	public BoulderResponse createBoulder(CreateBoulderRequest request) {

--- a/src/main/java/com/line7studio/boulderside/controller/boulder/BoulderController.java
+++ b/src/main/java/com/line7studio/boulderside/controller/boulder/BoulderController.java
@@ -1,8 +1,10 @@
 package com.line7studio.boulderside.controller.boulder;
 
+import com.line7studio.boulderside.common.security.details.CustomUserDetails;
 import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,17 +33,20 @@ public class BoulderController {
 
 	@GetMapping
 	public ResponseEntity<ApiResponse<BoulderPageResponse>> getBoulderPage(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestParam(defaultValue = "LATEST") BoulderSortType sortType,
 		@RequestParam(required = false) Long cursor,
 		@RequestParam(required = false) Long cursorLikeCount,
 		@RequestParam(defaultValue = "10") int size) {
-		BoulderPageResponse boulderPageResponse = boulderUseCase.getBoulderPage(sortType, cursor, cursorLikeCount, size);
+		BoulderPageResponse boulderPageResponse = boulderUseCase.getBoulderPage(userDetails.getUserId(), sortType, cursor, cursorLikeCount, size);
 		return ResponseEntity.ok(ApiResponse.of(boulderPageResponse));
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ApiResponse<BoulderResponse>> getBoulder(@PathVariable Long id) {
-		BoulderResponse boulder = boulderUseCase.getBoulderById(id);
+	public ResponseEntity<ApiResponse<BoulderResponse>> getBoulder(
+			@AuthenticationPrincipal CustomUserDetails userDetails,
+			@PathVariable Long id) {
+		BoulderResponse boulder = boulderUseCase.getBoulderById(userDetails.getUserId(), id);
 		return ResponseEntity.ok(ApiResponse.of(boulder));
 	}
 

--- a/src/main/java/com/line7studio/boulderside/controller/boulder/response/BoulderResponse.java
+++ b/src/main/java/com/line7studio/boulderside/controller/boulder/response/BoulderResponse.java
@@ -25,6 +25,7 @@ public class BoulderResponse {
 	private String province;
 	private String city;
 	private Long likeCount;
+	private boolean liked;
 	private List<ImageInfo> imageInfoList;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
@@ -63,7 +64,7 @@ public class BoulderResponse {
 	}
 
 	public static BoulderResponse of(BoulderWithRegion boulderWithRegion, List<ImageInfo> imageInfoList,
-		long likeCount) {
+		long likeCount, boolean isLiked) {
 		return BoulderResponse.builder()
 			.id(boulderWithRegion.getId())
 			.name(boulderWithRegion.getName())
@@ -74,6 +75,7 @@ public class BoulderResponse {
 			.city(boulderWithRegion.getCity())
 			.imageInfoList(imageInfoList)
 			.likeCount(likeCount)
+			.liked(isLiked)
 			.createdAt(boulderWithRegion.getCreatedAt())
 			.updatedAt(boulderWithRegion.getUpdatedAt())
 			.build();

--- a/src/main/java/com/line7studio/boulderside/domain/association/like/service/UserBoulderLikeService.java
+++ b/src/main/java/com/line7studio/boulderside/domain/association/like/service/UserBoulderLikeService.java
@@ -7,5 +7,7 @@ public interface UserBoulderLikeService {
 
 	long getCountByBoulderId(Long boulderId);
 
+	boolean getIsLikedByUserId(Long boulderId, Long userId);
+
 	void deleteAllByBoulderId(Long boulderId);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/association/like/service/UserBoulderLikeServiceImpl.java
+++ b/src/main/java/com/line7studio/boulderside/domain/association/like/service/UserBoulderLikeServiceImpl.java
@@ -42,6 +42,11 @@ public class UserBoulderLikeServiceImpl implements UserBoulderLikeService {
 	}
 
 	@Override
+	public boolean getIsLikedByUserId(Long boulderId, Long userId) {
+		return userBoulderLikeRepository.existsByUserIdAndBoulderId(userId, boulderId);
+	}
+
+	@Override
 	public void deleteAllByBoulderId(Long boulderId) {
 		if (boulderId == null) {
 			throw new ValidationException(ErrorCode.VALIDATION_FAILED);


### PR DESCRIPTION
## 📌 중점사항

- 바위 리스트 조회 시 현재 사용자의 좋아요 여부도 함께 조회할 수 있도록 수정하였습니다.

## ℹ️ 참고사항

- ...

## 🏷️ 이슈

- close #40 