### PR TITLE
회원 가입, 계정 연동 API 구현

### DIFF
--- a/src/main/java/com/line7studio/boulderside/application/user/UserUseCase.java
+++ b/src/main/java/com/line7studio/boulderside/application/user/UserUseCase.java
@@ -1,15 +1,6 @@
 package com.line7studio.boulderside.application.user;
 
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.line7studio.boulderside.application.user.dto.response.UserInfoResponse;
-import com.line7studio.boulderside.common.exception.BusinessException;
-import com.line7studio.boulderside.common.exception.ErrorCode;
-import com.line7studio.boulderside.common.exception.ExternalApiException;
 import com.line7studio.boulderside.common.security.provider.AESProvider;
 import com.line7studio.boulderside.controller.user.request.PhoneLinkRequest;
 import com.line7studio.boulderside.controller.user.request.SignupRequest;
@@ -21,9 +12,14 @@ import com.line7studio.boulderside.infrastructure.redis.RedisKeyPrefixType;
 import com.line7studio.boulderside.infrastructure.redis.RedisProvider;
 import com.line7studio.boulderside.infrastructure.s3.S3FolderType;
 import com.line7studio.boulderside.infrastructure.s3.S3Provider;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -34,7 +30,9 @@ public class UserUseCase {
 	private final PhoneAuthProvider phoneAuthProvider;
 	private final RedisProvider redisProvider;
 	private final S3Provider s3Provider;
+    private final Random random = new Random();
 
+    @Transactional(readOnly = true)
 	public UserInfoResponse getUserInfo(Long id) {
 		User user = userService.getUserById(id);
 		return UserInfoResponse.builder()
@@ -42,10 +40,12 @@ public class UserUseCase {
 			.build();
 	}
 
+    @Transactional(readOnly = true)
 	public boolean isUserIdDuplicate(String email) {
 		return userService.existsByEmail(email);
 	}
 
+    @Transactional(readOnly = true)
 	public boolean verifyAuthCode(String phoneNumber, String code) {
 		String encodedPhoneNumber = aesProvider.encrypt(phoneNumber);
 		String redisKey = RedisKeyPrefixType.PHONE_AUTH.of(encodedPhoneNumber);
@@ -60,83 +60,56 @@ public class UserUseCase {
 		return true;
 	}
 
+    @Transactional(readOnly = true)
 	public void sendAuthCode(String phoneNumber) {
+        // 인증번호 생성
+        String verificationCode = generateAuthCode();
 		String encodedPhoneNumber = aesProvider.encrypt(phoneNumber);
 
-		// 휴대폰 번호로 유저 존재 여부 확인
-		if (userService.existsByPhone(encodedPhoneNumber)) {
-			User existingUser = userService.getUserByPhone(encodedPhoneNumber);
+        // User 존재 여부 검증
+        userService.validateUserNotExistsByPhone(encodedPhoneNumber);
 
-			if (existingUser.getEmail() != null && !existingUser.getEmail().isBlank()) {
-				throw new ExternalApiException(ErrorCode.ACCOUNT_ALREADY_EXISTS);
-			}
-		}
-
-		String verificationCode = generateAuthCode();
+        // Redis 저장
 		String redisKey = RedisKeyPrefixType.PHONE_AUTH.of(encodedPhoneNumber);
-		try {
-			redisProvider.set(redisKey, verificationCode, 3, TimeUnit.MINUTES);
-		} catch (Exception e) {
-			log.error("Redis 저장 실패 - key={}, value={}, reason={}", redisKey, verificationCode, e.getMessage(), e);
-			throw new ExternalApiException(ErrorCode.REDIS_STORE_FAILED);
-		}
-
+        redisProvider.set(redisKey, verificationCode, 3, TimeUnit.MINUTES);
 		phoneAuthProvider.sendCertificationCode(phoneNumber, verificationCode);
 	}
 
+    @Transactional(readOnly = true)
 	public PhoneLookupResponse lookupUserByPhone(String phoneNumber) {
 		String encodedPhoneNumber = aesProvider.encrypt(phoneNumber);
-
-		try {
-			User user = userService.getUserByPhone(encodedPhoneNumber);
-			return PhoneLookupResponse.from(user);
-		} catch (BusinessException e) {
-			return PhoneLookupResponse.notExists();
-		}
+        User user = userService.getUserByPhone(encodedPhoneNumber);
+        return PhoneLookupResponse.from(user);
 	}
 
+    @Transactional
 	public void linkAccountByPhone(PhoneLinkRequest request) {
 		String encodedPhone = aesProvider.encrypt(request.phoneNumber());
 		userService.updateUserByPhone(encodedPhone, request.email(), request.password());
 	}
 
+    @Transactional
 	public void signUp(SignupRequest request, MultipartFile file) {
 		String encodedPhone = aesProvider.encrypt(request.phone());
 
-		// 이미지 저장하기
-		String profileImageUrl = null;
-		if (file != null && !file.isEmpty()) {
-			try {
-				profileImageUrl = s3Provider.imageUpload(file, S3FolderType.PROFILE).url();
-			} catch (Exception e) {
-				throw new ExternalApiException(ErrorCode.S3_INVALID_FILE_TYPE);
-			}
-		}
+        User savedUser = userService.createUser(
+                request.nickname(),
+                null,
+                encodedPhone,
+                request.userRole(),
+                request.userSex(),
+                request.userLevel(),
+                request.name(),
+                request.email(),
+                request.password()
+        );
 
-		// 데이터 저장
-		try {
-			userService.createUser(
-				request.nickname(),
-				profileImageUrl,
-				encodedPhone,
-				request.userRole(),
-				request.userSex(),
-				request.userLevel(),
-				request.name(),
-				request.email(),
-				request.password()
-			);
-		} catch (BusinessException e) {
-			s3Provider.deleteImageByUrl(profileImageUrl);
-			throw new ExternalApiException(e.getErrorCode());
-		}
-
-	}
+        String profileImageUrl = s3Provider.imageUpload(file, S3FolderType.PROFILE).url();
+        userService.updateUserProfileImage(savedUser.getId(), profileImageUrl);
+    }
 
 	private String generateAuthCode() {
-		Random random = new Random();
 		int code = 100000 + random.nextInt(900000);
 		return String.valueOf(code);
 	}
-
 }

--- a/src/main/java/com/line7studio/boulderside/application/user/UserUseCase.java
+++ b/src/main/java/com/line7studio/boulderside/application/user/UserUseCase.java
@@ -1,5 +1,6 @@
 package com.line7studio.boulderside.application.user;
 
+import com.line7studio.boulderside.application.user.dto.response.CreateUserCommand;
 import com.line7studio.boulderside.application.user.dto.response.UserInfoResponse;
 import com.line7studio.boulderside.common.security.provider.AESProvider;
 import com.line7studio.boulderside.controller.user.request.PhoneLinkRequest;
@@ -92,9 +93,8 @@ public class UserUseCase {
 	public void signUp(SignupRequest request, MultipartFile file) {
 		String encodedPhone = aesProvider.encrypt(request.phone());
 
-        User savedUser = userService.createUser(
+        CreateUserCommand createUserCommand = new CreateUserCommand(
                 request.nickname(),
-                null,
                 encodedPhone,
                 request.userRole(),
                 request.userSex(),
@@ -103,6 +103,9 @@ public class UserUseCase {
                 request.email(),
                 request.password()
         );
+
+        // 3) 유저 저장
+        User savedUser = userService.createUser(createUserCommand);
 
         String profileImageUrl = s3Provider.imageUpload(file, S3FolderType.PROFILE).url();
         userService.updateUserProfileImage(savedUser.getId(), profileImageUrl);

--- a/src/main/java/com/line7studio/boulderside/application/user/UserUseCase.java
+++ b/src/main/java/com/line7studio/boulderside/application/user/UserUseCase.java
@@ -4,17 +4,23 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.line7studio.boulderside.application.user.dto.response.UserInfoResponse;
+import com.line7studio.boulderside.common.exception.BusinessException;
 import com.line7studio.boulderside.common.exception.ErrorCode;
 import com.line7studio.boulderside.common.exception.ExternalApiException;
 import com.line7studio.boulderside.common.security.provider.AESProvider;
-import com.line7studio.boulderside.controller.user.response.LinkAccountResponse;
+import com.line7studio.boulderside.controller.user.request.PhoneLinkRequest;
+import com.line7studio.boulderside.controller.user.request.SignupRequest;
+import com.line7studio.boulderside.controller.user.response.PhoneLookupResponse;
 import com.line7studio.boulderside.domain.aggregate.user.entity.User;
 import com.line7studio.boulderside.domain.aggregate.user.provider.PhoneAuthProvider;
 import com.line7studio.boulderside.domain.aggregate.user.service.UserService;
 import com.line7studio.boulderside.infrastructure.redis.RedisKeyPrefixType;
 import com.line7studio.boulderside.infrastructure.redis.RedisProvider;
+import com.line7studio.boulderside.infrastructure.s3.S3FolderType;
+import com.line7studio.boulderside.infrastructure.s3.S3Provider;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +33,7 @@ public class UserUseCase {
 	private final AESProvider aesProvider;
 	private final PhoneAuthProvider phoneAuthProvider;
 	private final RedisProvider redisProvider;
+	private final S3Provider s3Provider;
 
 	public UserInfoResponse getUserInfo(Long id) {
 		User user = userService.getUserById(id);
@@ -77,11 +84,53 @@ public class UserUseCase {
 		phoneAuthProvider.sendCertificationCode(phoneNumber, verificationCode);
 	}
 
-	public LinkAccountResponse linkAccountWithPhone(String phoneNumber) {
+	public PhoneLookupResponse lookupUserByPhone(String phoneNumber) {
 		String encodedPhoneNumber = aesProvider.encrypt(phoneNumber);
-		User user = userService.getUserByPhone(encodedPhoneNumber);
 
-		return LinkAccountResponse.from(user);
+		try {
+			User user = userService.getUserByPhone(encodedPhoneNumber);
+			return PhoneLookupResponse.from(user);
+		} catch (BusinessException e) {
+			return PhoneLookupResponse.notExists();
+		}
+	}
+
+	public void linkAccountByPhone(PhoneLinkRequest request) {
+		String encodedPhone = aesProvider.encrypt(request.phoneNumber());
+		userService.updateUserByPhone(encodedPhone, request.email(), request.password());
+	}
+
+	public void signUp(SignupRequest request, MultipartFile file) {
+		String encodedPhone = aesProvider.encrypt(request.phone());
+
+		// 이미지 저장하기
+		String profileImageUrl = null;
+		if (file != null && !file.isEmpty()) {
+			try {
+				profileImageUrl = s3Provider.imageUpload(file, S3FolderType.PROFILE).url();
+			} catch (Exception e) {
+				throw new ExternalApiException(ErrorCode.S3_INVALID_FILE_TYPE);
+			}
+		}
+
+		// 데이터 저장
+		try {
+			userService.createUser(
+				request.nickname(),
+				profileImageUrl,
+				encodedPhone,
+				request.userRole(),
+				request.userSex(),
+				request.userLevel(),
+				request.name(),
+				request.email(),
+				request.password()
+			);
+		} catch (BusinessException e) {
+			s3Provider.deleteImageByUrl(profileImageUrl);
+			throw new ExternalApiException(e.getErrorCode());
+		}
+
 	}
 
 	private String generateAuthCode() {
@@ -89,4 +138,5 @@ public class UserUseCase {
 		int code = 100000 + random.nextInt(900000);
 		return String.valueOf(code);
 	}
+
 }

--- a/src/main/java/com/line7studio/boulderside/application/user/dto/response/CreateUserCommand.java
+++ b/src/main/java/com/line7studio/boulderside/application/user/dto/response/CreateUserCommand.java
@@ -1,0 +1,18 @@
+package com.line7studio.boulderside.application.user.dto.response;
+
+import com.line7studio.boulderside.common.enums.Level;
+import com.line7studio.boulderside.domain.aggregate.user.enums.UserRole;
+import com.line7studio.boulderside.domain.aggregate.user.enums.UserSex;
+import lombok.Builder;
+
+@Builder
+public record CreateUserCommand(
+        String nickname,
+        String encodedPhone,
+        UserRole userRole,
+        UserSex userSex,
+        Level userLevel,
+        String name,
+        String email,
+        String rawPassword
+) {}

--- a/src/main/java/com/line7studio/boulderside/common/security/constants/SecurityWhitelist.java
+++ b/src/main/java/com/line7studio/boulderside/common/security/constants/SecurityWhitelist.java
@@ -10,5 +10,6 @@ public final class SecurityWhitelist {
 
 	public static final String[] PUBLIC = {
 		"users/check-id", "users/phone/send-code", "users/phone/verify-code", "users/phone/link-account",
+		"users/phone/lookup", "users/phone/link-account", "users/sign-up"
 	};
 }

--- a/src/main/java/com/line7studio/boulderside/controller/user/UserController.java
+++ b/src/main/java/com/line7studio/boulderside/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package com.line7studio.boulderside.controller.user;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,16 +8,20 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.line7studio.boulderside.application.user.UserUseCase;
 import com.line7studio.boulderside.application.user.dto.response.UserInfoResponse;
 import com.line7studio.boulderside.common.response.ApiResponse;
 import com.line7studio.boulderside.common.security.details.CustomUserDetails;
-import com.line7studio.boulderside.controller.user.request.LinkAccountRequest;
 import com.line7studio.boulderside.controller.user.request.PhoneAuthRequest;
+import com.line7studio.boulderside.controller.user.request.PhoneLinkRequest;
+import com.line7studio.boulderside.controller.user.request.PhoneLookupRequest;
+import com.line7studio.boulderside.controller.user.request.SignupRequest;
 import com.line7studio.boulderside.controller.user.request.VerifyCodeRequest;
-import com.line7studio.boulderside.controller.user.response.LinkAccountResponse;
+import com.line7studio.boulderside.controller.user.response.PhoneLookupResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -51,10 +56,28 @@ public class UserController {
 		return ResponseEntity.ok(ApiResponse.of(response));
 	}
 
-	@PostMapping("/phone/link-account")
-	public ResponseEntity<ApiResponse<LinkAccountResponse>> linkPhoneAccount(
-		@RequestBody LinkAccountRequest request) {
-		LinkAccountResponse response = userUseCase.linkAccountWithPhone(request.phoneNumber());
+	@PostMapping("/phone/lookup")
+	public ResponseEntity<ApiResponse<PhoneLookupResponse>> checkPhone(
+		@RequestBody PhoneLookupRequest request) {
+		PhoneLookupResponse response = userUseCase.lookupUserByPhone(request.phoneNumber());
 		return ResponseEntity.ok(ApiResponse.of(response));
 	}
+
+	@PostMapping("/phone/link-account")
+	public ResponseEntity<ApiResponse<Void>> linkPhoneAccount(
+		@RequestBody PhoneLinkRequest request) {
+
+		userUseCase.linkAccountByPhone(request);
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	@PostMapping(value = "/sign-up", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<ApiResponse<Void>> signUp(
+		@RequestPart("data") SignupRequest request,
+		@RequestPart(value = "file", required = false) MultipartFile file
+	) {
+		userUseCase.signUp(request, file);
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
 }

--- a/src/main/java/com/line7studio/boulderside/controller/user/request/LinkAccountRequest.java
+++ b/src/main/java/com/line7studio/boulderside/controller/user/request/LinkAccountRequest.java
@@ -1,5 +1,0 @@
-package com.line7studio.boulderside.controller.user.request;
-
-public record LinkAccountRequest(String phoneNumber) {
-	
-}

--- a/src/main/java/com/line7studio/boulderside/controller/user/request/PhoneLinkRequest.java
+++ b/src/main/java/com/line7studio/boulderside/controller/user/request/PhoneLinkRequest.java
@@ -1,0 +1,10 @@
+package com.line7studio.boulderside.controller.user.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PhoneLinkRequest(
+	@NotBlank String phoneNumber,
+	@NotBlank String email,
+	@NotBlank String password
+) {
+}

--- a/src/main/java/com/line7studio/boulderside/controller/user/request/PhoneLookupRequest.java
+++ b/src/main/java/com/line7studio/boulderside/controller/user/request/PhoneLookupRequest.java
@@ -1,0 +1,7 @@
+package com.line7studio.boulderside.controller.user.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PhoneLookupRequest(@NotBlank String phoneNumber) {
+
+}

--- a/src/main/java/com/line7studio/boulderside/controller/user/request/SignupRequest.java
+++ b/src/main/java/com/line7studio/boulderside/controller/user/request/SignupRequest.java
@@ -1,0 +1,19 @@
+package com.line7studio.boulderside.controller.user.request;
+
+import com.line7studio.boulderside.common.enums.Level;
+import com.line7studio.boulderside.domain.aggregate.user.enums.UserRole;
+import com.line7studio.boulderside.domain.aggregate.user.enums.UserSex;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SignupRequest(
+	@NotBlank String nickname,
+	@NotBlank String phone,
+	UserRole userRole,
+	UserSex userSex,
+	Level userLevel,
+	String name,
+	@NotBlank String email,
+	@NotBlank String password
+) {
+}

--- a/src/main/java/com/line7studio/boulderside/controller/user/response/PhoneLookupResponse.java
+++ b/src/main/java/com/line7studio/boulderside/controller/user/response/PhoneLookupResponse.java
@@ -8,7 +8,8 @@ import com.line7studio.boulderside.domain.aggregate.user.enums.UserSex;
 import lombok.Builder;
 
 @Builder
-public record LinkAccountResponse(
+public record PhoneLookupResponse(
+	boolean exists,
 	String nickname,
 	String phone,
 	UserRole userRole,
@@ -16,14 +17,26 @@ public record LinkAccountResponse(
 	Level userLevel,
 	String name
 ) {
-	public static LinkAccountResponse from(User user) {
-		return LinkAccountResponse.builder()
+	public static PhoneLookupResponse from(User user) {
+		if (user == null) {
+			return PhoneLookupResponse.builder()
+				.exists(false)
+				.build();
+		}
+		return PhoneLookupResponse.builder()
+			.exists(true)
 			.nickname(user.getNickname())
 			.phone(user.getPhone())
 			.userRole(user.getUserRole())
 			.userSex(user.getUserSex())
 			.userLevel(user.getUserLevel())
 			.name(user.getName())
+			.build();
+	}
+
+	public static PhoneLookupResponse notExists() {
+		return PhoneLookupResponse.builder()
+			.exists(false)
 			.build();
 	}
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/user/entity/User.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/user/entity/User.java
@@ -34,9 +34,9 @@ public class User extends BaseEntity {
 	@Column(name = "nickname", nullable = false)
 	private String nickname;
 
-    /** 사용자 프로필 이미지 */
-    @Column(name = "profile_image_url")
-    private String profileImageUrl;
+	/** 사용자 프로필 이미지 */
+	@Column(name = "profile_image_url")
+	private String profileImageUrl;
 
 	/** 휴대폰 번호 */
 	@Column(name = "phone")
@@ -45,7 +45,8 @@ public class User extends BaseEntity {
 	/** 사용자 역할 (예: ADMIN, USER 등) */
 	@Enumerated(EnumType.STRING)
 	@Column(name = "user_role", nullable = false)
-	private UserRole userRole;
+	@Builder.Default
+	private UserRole userRole = UserRole.ROLE_USER;
 
 	/** 성별 */
 	@Enumerated(EnumType.STRING)
@@ -55,7 +56,8 @@ public class User extends BaseEntity {
 	/** 사용자 레벨 (공통 Level enum 사용) */
 	@Enumerated(EnumType.STRING)
 	@Column(name = "user_level")
-	private Level userLevel;
+	@Builder.Default
+	private Level userLevel = Level.V0;
 
 	/** 실제 이름 */
 	@Column(name = "name")
@@ -67,4 +69,10 @@ public class User extends BaseEntity {
 
 	@Column(name = "password")
 	private String password;
+
+	public void updateAccount(String email, String encodedPassword) {
+		this.email = email;
+		this.password = encodedPassword;
+	}
+
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/user/entity/User.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/user/entity/User.java
@@ -75,4 +75,8 @@ public class User extends BaseEntity {
 		this.password = encodedPassword;
 	}
 
+	public void updateProfileImage(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
+
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/user/service/UserService.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/user/service/UserService.java
@@ -2,16 +2,24 @@ package com.line7studio.boulderside.domain.aggregate.user.service;
 
 import java.util.List;
 
+import com.line7studio.boulderside.common.enums.Level;
 import com.line7studio.boulderside.domain.aggregate.user.entity.User;
+import com.line7studio.boulderside.domain.aggregate.user.enums.UserRole;
+import com.line7studio.boulderside.domain.aggregate.user.enums.UserSex;
 
 public interface UserService {
 	User getUserById(Long userId);
 
 	User getUserByPhone(String phoneNumber);
 
+	User updateUserByPhone(String phoneNumber, String email, String password);
+
 	List<User> findAllById(List<Long> userIdList);
 
 	boolean existsByEmail(String email);
 
 	boolean existsByPhone(String phone);
+
+	User createUser(String nickname, String profileImageUrl, String phone, UserRole userRole, UserSex userSex,
+		Level userLevel, String name, String email, String password);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/user/service/UserService.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/user/service/UserService.java
@@ -1,25 +1,24 @@
 package com.line7studio.boulderside.domain.aggregate.user.service;
 
-import java.util.List;
-
-import com.line7studio.boulderside.common.enums.Level;
+import com.line7studio.boulderside.application.user.dto.response.CreateUserCommand;
 import com.line7studio.boulderside.domain.aggregate.user.entity.User;
-import com.line7studio.boulderside.domain.aggregate.user.enums.UserRole;
-import com.line7studio.boulderside.domain.aggregate.user.enums.UserSex;
+
+import java.util.List;
 
 public interface UserService {
 	User getUserById(Long userId);
 
 	User getUserByPhone(String phoneNumber);
 
-	User updateUserByPhone(String phoneNumber, String email, String password);
+	void updateUserByPhone(String phoneNumber, String email, String password);
 
 	List<User> findAllById(List<Long> userIdList);
 
 	boolean existsByEmail(String email);
 
-	boolean existsByPhone(String phone);
+	User createUser(CreateUserCommand createUserCommand);
 
-	User createUser(String nickname, String profileImageUrl, String phone, UserRole userRole, UserSex userSex,
-		Level userLevel, String name, String email, String password);
+	void updateUserProfileImage(Long userId, String profileImageUrl);
+
+    void validateUserNotExistsByPhone(String encodedPhoneNumber);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/user/service/UserServiceImpl.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/user/service/UserServiceImpl.java
@@ -1,25 +1,20 @@
 package com.line7studio.boulderside.domain.aggregate.user.service;
 
-import java.util.List;
-
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.line7studio.boulderside.common.enums.Level;
+import com.line7studio.boulderside.application.user.dto.response.CreateUserCommand;
 import com.line7studio.boulderside.common.exception.BusinessException;
 import com.line7studio.boulderside.common.exception.ErrorCode;
+import com.line7studio.boulderside.common.exception.ExternalApiException;
 import com.line7studio.boulderside.domain.aggregate.user.entity.User;
-import com.line7studio.boulderside.domain.aggregate.user.enums.UserRole;
-import com.line7studio.boulderside.domain.aggregate.user.enums.UserSex;
 import com.line7studio.boulderside.domain.aggregate.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Slf4j
 public class UserServiceImpl implements UserService {
 
@@ -38,40 +33,30 @@ public class UserServiceImpl implements UserService {
 			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}
 
-	@Override
+    @Override
 	public boolean existsByEmail(String email) {
 		return userRepository.existsByEmail(email);
 	}
 
 	@Override
-	public boolean existsByPhone(String phone) {
-		return userRepository.existsByPhone(phone);
-	}
-
-	@Override
-	@Transactional
-	public User createUser(String nickname, String profileImageUrl, String phone, UserRole userRole, UserSex userSex,
-		Level userLevel, String name, String email, String password) {
-		if (userRepository.existsByEmail(email) || userRepository.existsByPhone(phone)) {
+	public User createUser(CreateUserCommand createUserCommand) {
+		if (existsByEmail(createUserCommand.email()) &&
+                userRepository.existsByPhone(createUserCommand.encodedPhone())) {
 			throw new BusinessException(ErrorCode.ACCOUNT_ALREADY_EXISTS);
 		}
 
-		User user = User.builder()
-			.nickname(nickname)
-			.profileImageUrl(profileImageUrl)
-			.phone(phone)
-			.userRole(userRole)
-			.userSex(userSex)
-			.userLevel(userLevel)
-			.name(name)
-			.email(email)
-			.password(passwordEncoder.encode(password))
-			.build();
+        User user = User.builder()
+                .nickname(createUserCommand.nickname())
+                .phone(createUserCommand.encodedPhone())
+                .userRole(createUserCommand.userRole())
+                .userSex(createUserCommand.userSex())
+                .userLevel(createUserCommand.userLevel())
+                .name(createUserCommand.name())
+                .email(createUserCommand.email())
+                .password(passwordEncoder.encode(createUserCommand.rawPassword()))
+                .build();
 
-		User savedUser = userRepository.save(user);
-		log.info("[회원가입 완료] userId={}, email={}, nickname={}", savedUser.getId(), savedUser.getEmail(),
-			savedUser.getNickname());
-		return savedUser;
+        return userRepository.save(user);
 	}
 
 	@Override
@@ -80,8 +65,7 @@ public class UserServiceImpl implements UserService {
 	}
 
 	@Override
-	@Transactional(readOnly = false)
-	public User updateUserByPhone(String phoneNumber, String email, String password) {
+	public void updateUserByPhone(String phoneNumber, String email, String password) {
 		User user = userRepository.findByPhone(phoneNumber)
 			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -94,7 +78,24 @@ public class UserServiceImpl implements UserService {
 		log.info("[계정 연동 완료] userId={}, phone={}, email={}",
 			savedUser.getId(), savedUser.getPhone(), savedUser.getEmail());
 
-		return savedUser;
-	}
+    }
 
+	@Override
+	public void updateUserProfileImage(Long userId, String profileImageUrl) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		user.updateProfileImage(profileImageUrl);
+		User savedUser = userRepository.save(user);
+		log.info("[프로필 이미지 업데이트 완료] userId={}, profileImageUrl={}", 
+			savedUser.getId(), savedUser.getProfileImageUrl());
+    }
+
+    @Override
+    public void validateUserNotExistsByPhone(String encodedPhoneNumber) {
+        User user = getUserByPhone(encodedPhoneNumber);
+        if (user.getEmail() != null && !user.getEmail().isBlank()) {
+            throw new ExternalApiException(ErrorCode.ACCOUNT_ALREADY_EXISTS);
+        }
+    }
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/user/service/UserServiceImpl.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/user/service/UserServiceImpl.java
@@ -2,22 +2,29 @@ package com.line7studio.boulderside.domain.aggregate.user.service;
 
 import java.util.List;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.line7studio.boulderside.common.enums.Level;
 import com.line7studio.boulderside.common.exception.BusinessException;
 import com.line7studio.boulderside.common.exception.ErrorCode;
 import com.line7studio.boulderside.domain.aggregate.user.entity.User;
+import com.line7studio.boulderside.domain.aggregate.user.enums.UserRole;
+import com.line7studio.boulderside.domain.aggregate.user.enums.UserSex;
 import com.line7studio.boulderside.domain.aggregate.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class UserServiceImpl implements UserService {
 
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	@Override
 	public User getUserById(Long userId) {
@@ -42,8 +49,52 @@ public class UserServiceImpl implements UserService {
 	}
 
 	@Override
+	@Transactional
+	public User createUser(String nickname, String profileImageUrl, String phone, UserRole userRole, UserSex userSex,
+		Level userLevel, String name, String email, String password) {
+		if (userRepository.existsByEmail(email) || userRepository.existsByPhone(phone)) {
+			throw new BusinessException(ErrorCode.ACCOUNT_ALREADY_EXISTS);
+		}
+
+		User user = User.builder()
+			.nickname(nickname)
+			.profileImageUrl(profileImageUrl)
+			.phone(phone)
+			.userRole(userRole)
+			.userSex(userSex)
+			.userLevel(userLevel)
+			.name(name)
+			.email(email)
+			.password(passwordEncoder.encode(password))
+			.build();
+
+		User savedUser = userRepository.save(user);
+		log.info("[회원가입 완료] userId={}, email={}, nickname={}", savedUser.getId(), savedUser.getEmail(),
+			savedUser.getNickname());
+		return savedUser;
+	}
+
+	@Override
 	public List<User> findAllById(List<Long> userIdList) {
 		return userRepository.findAllByIdIn(userIdList);
+	}
+
+	@Override
+	@Transactional(readOnly = false)
+	public User updateUserByPhone(String phoneNumber, String email, String password) {
+		User user = userRepository.findByPhone(phoneNumber)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		if (user.getEmail() != null && !user.getEmail().isBlank()) {
+			throw new BusinessException(ErrorCode.ACCOUNT_ALREADY_EXISTS);
+		}
+
+		user.updateAccount(email, passwordEncoder.encode(password));
+		User savedUser = userRepository.save(user);
+		log.info("[계정 연동 완료] userId={}, phone={}, email={}",
+			savedUser.getId(), savedUser.getPhone(), savedUser.getEmail());
+
+		return savedUser;
 	}
 
 }

--- a/src/main/java/com/line7studio/boulderside/infrastructure/redis/RedisProvider.java
+++ b/src/main/java/com/line7studio/boulderside/infrastructure/redis/RedisProvider.java
@@ -1,12 +1,11 @@
 package com.line7studio.boulderside.infrastructure.redis;
 
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/line7studio/boulderside/infrastructure/s3/S3Provider.java
+++ b/src/main/java/com/line7studio/boulderside/infrastructure/s3/S3Provider.java
@@ -1,25 +1,23 @@
 package com.line7studio.boulderside.infrastructure.s3;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.List;
-import java.util.UUID;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.line7studio.boulderside.common.exception.BusinessException;
 import com.line7studio.boulderside.common.exception.ErrorCode;
 import com.line7studio.boulderside.common.exception.ExternalApiException;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Component
@@ -31,8 +29,8 @@ public class S3Provider {
 	private final AmazonS3 amazonS3;
 
 	// S3 이미지 업로드
-	public S3ObjectInfo imageUpload(MultipartFile file, S3FolderType folder) throws IOException {
-		String fileName = file.getOriginalFilename();
+	public S3ObjectInfo imageUpload(MultipartFile file, S3FolderType folder) {
+        String fileName = file.getOriginalFilename();
 
 		// 확장자 검증(스푸핑 가능)
 		String ext = fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
@@ -60,7 +58,9 @@ public class S3Provider {
 				new PutObjectRequest(bucket, s3FilePathName, inputStream, metadata)
 					.withCannedAcl(CannedAccessControlList.PublicRead)
 			);
-		}
+		} catch (Exception e) {
+            throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED);
+        }
 
 		String s3Url = amazonS3.getUrl(bucket, s3FilePathName).toString();
 		return S3ObjectInfo.of(s3Url, fileName);


### PR DESCRIPTION
## 📌 중점사항

- [x] 회원 가입 API

## ℹ️ 참고사항
* **휴대폰 번호 기반 계정 조회 (`/phone/lookup`)**

  * 입력된 휴대폰 번호로 기존 계정이 존재하는지 확인하고, 해당 계정 정보를 응답

* **휴대폰 번호 계정 연동 (`/phone/link-account`)**

  * 이미 존재하는 휴대폰 번호를 기반으로 신규 계정을 연동
  * 계정 통합 및 연동 로직 처리

* **회원가입 (`/sign-up`)**

  * 신규 회원 정보를 입력받아 계정을 생성
  * 프로필 이미지 파일 업로드 기능 포함 (S3 저장)

### 📌 PR 내용 정리

## 🏷️ 이슈
- close #44