### PR TITLE
검색 기능 커서 기반 페이징 로직 수정

### DIFF
--- a/src/main/java/com/line7studio/boulderside/application/search/SearchUseCase.java
+++ b/src/main/java/com/line7studio/boulderside/application/search/SearchUseCase.java
@@ -45,35 +45,19 @@ public class SearchUseCase {
         return searchService.searchUnified(keyword);
     }
 
-    public DomainSearchResponse searchByDomain(String keyword, DocumentDomainType domain, String cursor, int size) {
+    public DomainSearchResponse searchByDomain(String keyword, DocumentDomainType domain, int size) {
         if (keyword == null || keyword.trim().isEmpty()) {
             return DomainSearchResponse.builder()
                     .items(List.of())
-                    .nextCursor(null)
-                    .hasMore(false)
                     .totalCount(0)
                     .build();
         }
         
-        List<SearchItemResponse> items = searchService.searchByDomain(keyword, domain, cursor, size + 1);
-        
-        boolean hasMore = items.size() > size;
-        if (hasMore) {
-            items = items.subList(0, size);
-        }
-        
-        String nextCursor = null;
-        if (hasMore && !items.isEmpty()) {
-            SearchItemResponse lastItem = items.getLast();
-            nextCursor = lastItem.getCreatedAt().toString();
-        }
-        
+        List<SearchItemResponse> items = searchService.searchByDomain(keyword, domain, size);
         long totalCount = searchService.countByDomain(keyword, domain);
         
         return DomainSearchResponse.builder()
                 .items(items)
-                .nextCursor(nextCursor)
-                .hasMore(hasMore)
                 .totalCount(totalCount)
                 .build();
     }

--- a/src/main/java/com/line7studio/boulderside/application/search/dto/DomainSearchResponse.java
+++ b/src/main/java/com/line7studio/boulderside/application/search/dto/DomainSearchResponse.java
@@ -13,7 +13,5 @@ import java.util.List;
 @AllArgsConstructor
 public class DomainSearchResponse {
     private List<SearchItemResponse> items;
-    private String nextCursor;
-    private boolean hasMore;
     private long totalCount;
 }

--- a/src/main/java/com/line7studio/boulderside/controller/boulder/BoulderController.java
+++ b/src/main/java/com/line7studio/boulderside/controller/boulder/BoulderController.java
@@ -1,29 +1,19 @@
 package com.line7studio.boulderside.controller.boulder;
 
-import com.line7studio.boulderside.common.security.details.CustomUserDetails;
-import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.line7studio.boulderside.application.boulder.BoulderUseCase;
 import com.line7studio.boulderside.common.response.ApiResponse;
+import com.line7studio.boulderside.common.security.details.CustomUserDetails;
 import com.line7studio.boulderside.controller.boulder.request.CreateBoulderRequest;
 import com.line7studio.boulderside.controller.boulder.request.UpdateBoulderRequest;
 import com.line7studio.boulderside.controller.boulder.response.BoulderPageResponse;
 import com.line7studio.boulderside.controller.boulder.response.BoulderResponse;
-
+import com.line7studio.boulderside.domain.aggregate.boulder.enums.BoulderSortType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/boulders")
@@ -38,8 +28,8 @@ public class BoulderController {
 		@RequestParam(required = false) Long cursor,
 		@RequestParam(required = false) String subCursor,
 		@RequestParam(defaultValue = "5") int size) {
-		BoulderPageResponse boulderPageResponse = boulderUseCase.getBoulderPage(userDetails.getUserId(), boulderSortType, cursor, subCursor, size);
-		return ResponseEntity.ok(ApiResponse.of(boulderPageResponse));
+        BoulderPageResponse boulderPageResponse = boulderUseCase.getBoulderPage(userDetails.getUserId(), boulderSortType, cursor, subCursor, size);
+        return ResponseEntity.ok(ApiResponse.of(boulderPageResponse));
 	}
 
 	@GetMapping("/{boulderId}")

--- a/src/main/java/com/line7studio/boulderside/controller/search/SearchController.java
+++ b/src/main/java/com/line7studio/boulderside/controller/search/SearchController.java
@@ -38,9 +38,8 @@ public class SearchController {
     public ResponseEntity<ApiResponse<DomainSearchResponse>> searchByDomain(
             @RequestParam String keyword,
             @RequestParam DocumentDomainType domain,
-            @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "20") int size) {
-        DomainSearchResponse response = searchUseCase.searchByDomain(keyword, domain, cursor, size);
+            @RequestParam(defaultValue = "10") int size) {
+        DomainSearchResponse response = searchUseCase.searchByDomain(keyword, domain, size);
         return ResponseEntity.ok(ApiResponse.of(response));
     }
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/search/repository/SearchRepository.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/search/repository/SearchRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 public interface SearchRepository {
     List<String> findSuggestionsWithKeyword(String keyword, int limit);
     UnifiedSearchResponse searchUnified(String keyword);
-    List<SearchItemResponse> searchByDomain(String keyword, DocumentDomainType domain, String cursor, int size);
+    List<SearchItemResponse> searchByDomain(String keyword, DocumentDomainType domain, int size);
     long countByDomain(String keyword, DocumentDomainType domain);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/search/service/SearchService.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/search/service/SearchService.java
@@ -9,6 +9,6 @@ import java.util.List;
 public interface SearchService {
     List<String> findSuggestionsWithKeyword(String keyword, int limit);
     UnifiedSearchResponse searchUnified(String keyword);
-    List<SearchItemResponse> searchByDomain(String keyword, DocumentDomainType domain, String cursor, int size);
+    List<SearchItemResponse> searchByDomain(String keyword, DocumentDomainType domain, int size);
     long countByDomain(String keyword, DocumentDomainType domain);
 }

--- a/src/main/java/com/line7studio/boulderside/domain/aggregate/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/line7studio/boulderside/domain/aggregate/search/service/SearchServiceImpl.java
@@ -26,8 +26,8 @@ public class SearchServiceImpl implements SearchService {
     }
 
     @Override
-    public List<SearchItemResponse> searchByDomain(String keyword, DocumentDomainType domain, String cursor, int size) {
-        return searchRepository.searchByDomain(keyword, domain, cursor, size);
+    public List<SearchItemResponse> searchByDomain(String keyword, DocumentDomainType domain, int size) {
+        return searchRepository.searchByDomain(keyword, domain, size);
     }
 
     @Override

--- a/src/main/java/com/line7studio/boulderside/infrastructure/elasticsearch/repository/SearchRepositoryImpl.java
+++ b/src/main/java/com/line7studio/boulderside/infrastructure/elasticsearch/repository/SearchRepositoryImpl.java
@@ -96,7 +96,7 @@ public class SearchRepositoryImpl implements ElasticsearchSearchRepository {
         boulderQuery.setPageable(org.springframework.data.domain.PageRequest.of(0, 4));
         SearchHits<BoulderDocument> boulderHits = elasticsearchOperations.search(boulderQuery, BoulderDocument.class);
         List<SearchItemResponse> boulderItems = boulderHits.stream()
-                .limit(3)
+                .limit(4)
                 .map(SearchHit::getContent)
                 .map(this::convertBoulderToSearchItem)
                 .toList();
@@ -121,7 +121,7 @@ public class SearchRepositoryImpl implements ElasticsearchSearchRepository {
         routeQuery.setPageable(org.springframework.data.domain.PageRequest.of(0, 4));
         SearchHits<RouteDocument> routeHits = elasticsearchOperations.search(routeQuery, RouteDocument.class);
         List<SearchItemResponse> routeItems = routeHits.stream()
-                .limit(3)
+                .limit(4)
                 .map(SearchHit::getContent)
                 .map(this::convertRouteToSearchItem)
                 .toList();
@@ -146,7 +146,7 @@ public class SearchRepositoryImpl implements ElasticsearchSearchRepository {
         postQuery.setPageable(org.springframework.data.domain.PageRequest.of(0, 4));
         SearchHits<PostDocument> postHits = elasticsearchOperations.search(postQuery, PostDocument.class);
         List<SearchItemResponse> postItems = postHits.stream()
-                .limit(3)
+                .limit(4)
                 .map(SearchHit::getContent)
                 .map(this::convertPostToSearchItem)
                 .toList();
@@ -165,41 +165,18 @@ public class SearchRepositoryImpl implements ElasticsearchSearchRepository {
     }
 
     @Override
-    public List<SearchItemResponse> searchByDomain(String keyword, DocumentDomainType domain, String cursor, int size) {
+    public List<SearchItemResponse> searchByDomain(String keyword, DocumentDomainType domain, int size) {
         String searchField = getSearchField(domain);
         Class<?> documentClass = getDocumentClass(domain);
 
-        String queryString;
-        if (cursor != null) {
-            queryString = """
-                {
-                    "bool": {
-                        "must": {
-                            "multi_match": {
-                                "query": "%s",
-                                "fields": ["%s"]
-                            }
-                        },
-                        "filter": {
-                            "range": {
-                                "createdAt": {
-                                    "lt": "%s"
-                                }
-                            }
-                        }
-                    }
+        String queryString = """
+            {
+                "multi_match": {
+                    "query": "%s",
+                    "fields": ["%s"]
                 }
-                """.formatted(keyword, searchField, cursor);
-        } else {
-            queryString = """
-                {
-                    "multi_match": {
-                        "query": "%s",
-                        "fields": ["%s"]
-                    }
-                }
-                """.formatted(keyword, searchField);
-        }
+            }
+            """.formatted(keyword, searchField);
 
         StringQuery query = new StringQuery(queryString);
         query.setPageable(org.springframework.data.domain.PageRequest.of(0, size));


### PR DESCRIPTION
## 📌 중점사항

- 바위 목록 조회시 페이징 기능을 임시로 제거했습니다.
- 통합 검색 결과가 각 도메인당 3개 초과인 경우 더보기 버튼을 노출해야하므로 데이터를 4개 조회하도록 수정했습니다.

## ℹ️ 참고사항

- ...

## 🏷️ 이슈

- close #57 